### PR TITLE
Put `serde` behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ edition = "2018"
 
 
 [features]
-default = ["std"]
+default = ["std","serde"]
 std = ["num-traits/std","roots"]
 
 [dependencies]
 roots = {version="0.0.6",optional = true }
 num-traits = {version="0.2",default-features = false}
-serde={version="1.0", features=["derive"] ,default-features = false}
+serde={version="1.0", features=["derive"] ,default-features = false,optional=true}
 partial-min-max = "0.4.0"

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -18,7 +18,8 @@ pub fn vec2same<N: Copy>(a: N) -> Vec2<N> {
 }
 
 ///A 2D vector.
-#[derive(Default,Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[must_use]
 pub struct Vec2<N> {
     pub x: N,


### PR DESCRIPTION
This way broccoli can be used without using the serde dependency. By default, it's enabled so nothing changes API-wise, although I would recommend disabling it by default.